### PR TITLE
Add UE5 overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is the documentation for the Community-supported HTML5 Platform Extension f
 
 * * *
 
+Additional resources for **Unreal Engine 5**:
+
+- [UE5 Documentation Overview](UE5Overview.md)
+
 After **linking your [Epic Games Account](https://www.epicgames.com/account/connected) to your GitHub account**,
 you can find the HTML5 Platform Extenion repository [HERE](https://github.com/UnrealEngineHTML5/UnrealEngine/tree/4.24.3-html5-1.39.18/Engine/Platforms/HTML5).
 

--- a/UE5Overview.md
+++ b/UE5Overview.md
@@ -1,0 +1,38 @@
+# Unreal Engine 5 Documentation Overview
+
+This repository focuses on the community-supported HTML5 platform extension for Unreal Engine 4. For Unreal Engine 5, Epic maintains extensive official documentation.
+
+## Getting Started with UE5
+
+The official UE5 documentation provides step-by-step guides for installing the engine, creating projects, and using new features such as Nanite, Lumen, MetaSounds and Chaos physics.
+
+A minimal C++ class example:
+
+```cpp
+#include "GameFramework/Actor.h"
+#include "MyActor.generated.h"
+
+UCLASS()
+class AMyActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AMyActor();
+
+protected:
+    virtual void BeginPlay() override;
+
+public:
+    virtual void Tick(float DeltaTime) override;
+};
+```
+
+## Useful Links
+
+- [Official Unreal Engine 5 Documentation](https://docs.unrealengine.com/5.0/en-US/)
+- [Blueprint Visual Scripting](https://docs.unrealengine.com/5.0/en-US/Blueprints/)
+- [C++ Programming in UE5](https://docs.unrealengine.com/5.0/en-US/ProgrammingAndScripting/ProgrammingWithCPP/)
+- [Samples and Tutorials](https://docs.unrealengine.com/5.0/en-US/Community/SampleProjects/)
+
+These resources contain detailed explanations and usage examples for every major feature of the engine.


### PR DESCRIPTION
## Summary
- add introductory docs for Unreal Engine 5 features
- link UE5 overview from the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684757bc68a483328c2f606feffcc95b